### PR TITLE
feat: implement localcache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/JunKaiChuang/go_training
+
+go 1.20

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/JunKaiChuang/go_training
 
-go 1.20
+go 1.19

--- a/main.go
+++ b/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/JunKaiChuang/go_training/pkg/localcache"
+)
+
+func main() {
+	cache := localcache.New()
+
+	cache.Set("hello", "world")
+
+	fmt.Println(cache.Get("hello"))
+
+	cache.Set("hello", "universe")
+
+	fmt.Println(cache.Get("hello"))
+
+	time.Sleep(2 * time.Second)
+
+	fmt.Println(cache.Get("hello"))
+
+	time.Sleep(30 * time.Second)
+
+	fmt.Println(cache.Get("hello"))
+
+	cache.Set("hello", "cat")
+
+	fmt.Println(cache.Get("hello"))
+
+	fmt.Println("end")
+}

--- a/pkg/localcache/interface.go
+++ b/pkg/localcache/interface.go
@@ -5,6 +5,4 @@ type Cache interface {
 	Get(k string) any
 	// Set the v(data) to the cache with k(key)
 	Set(k string, v any)
-	// Get the cache map
-	CacheMap() map[string]cacheData
 }

--- a/pkg/localcache/interface.go
+++ b/pkg/localcache/interface.go
@@ -1,0 +1,8 @@
+package localcache
+
+type Cache interface {
+	// Get the data from the cache with k(key)
+	Get(k string) any
+	// Set the v(data) to the cache with k(key)
+	Set(k string, v any)
+}

--- a/pkg/localcache/interface.go
+++ b/pkg/localcache/interface.go
@@ -5,4 +5,6 @@ type Cache interface {
 	Get(k string) any
 	// Set the v(data) to the cache with k(key)
 	Set(k string, v any)
+	// Get the cache map
+	CacheMap() map[string]cacheData
 }

--- a/pkg/localcache/localcache.go
+++ b/pkg/localcache/localcache.go
@@ -1,0 +1,59 @@
+// Store the data in the local memory
+package localcache
+
+import "time"
+
+const (
+	// TTL is the default time to live(seconds) for a cache entry
+	TTL = 30
+)
+
+var (
+	// function variable of time.Now
+	timeNow = time.Now
+)
+
+type cacheData struct {
+	Data     any
+	ExpireAt time.Time
+}
+
+type cache struct {
+	cacheMap map[string]cacheData
+}
+
+// Returns a new Cache instance
+func New() Cache {
+	return &cache{
+		cacheMap: make(map[string]cacheData),
+	}
+}
+
+// Get the data from the cache with k(key)
+func (c cache) Get(k string) any {
+	now := timeNow()
+	val, ok := c.cacheMap[k]
+
+	if !ok {
+		return nil
+	}
+
+	if now.After(val.ExpireAt) {
+		delete(c.cacheMap, k)
+		return nil
+	}
+
+	return val.Data
+}
+
+// Set the v(data) to the cache with k(key)
+func (c cache) Set(k string, v any) {
+	c.cacheMap[k] = cacheData{
+		Data:     v,
+		ExpireAt: expireAt(),
+	}
+}
+
+func expireAt() time.Time {
+	return timeNow().Add(TTL * time.Second)
+}

--- a/pkg/localcache/localcache.go
+++ b/pkg/localcache/localcache.go
@@ -4,13 +4,17 @@ package localcache
 import "time"
 
 const (
-	// TTL is the default time to live(seconds) for a cache entry
-	TTL = 30
+	// cacheTTL is the default time to live(seconds) for a cache entry
+	cacheTTL = 30
 )
 
 var (
 	// function variable of time.Now
 	timeNow = time.Now
+	// function variable of make cache map
+	initCacheMap = func() map[string]cacheData {
+		return make(map[string]cacheData)
+	}
 )
 
 type cacheData struct {
@@ -25,7 +29,7 @@ type cache struct {
 // Returns a new Cache instance
 func New() Cache {
 	return &cache{
-		cacheMap: make(map[string]cacheData),
+		cacheMap: initCacheMap(),
 	}
 }
 
@@ -54,6 +58,11 @@ func (c cache) Set(k string, v any) {
 	}
 }
 
+// Get the cache map
+func (c cache) CacheMap() map[string]cacheData {
+	return c.cacheMap
+}
+
 func expireAt() time.Time {
-	return timeNow().Add(TTL * time.Second)
+	return timeNow().Add(cacheTTL * time.Second)
 }

--- a/pkg/localcache/localcache.go
+++ b/pkg/localcache/localcache.go
@@ -11,10 +11,6 @@ const (
 var (
 	// function variable of time.Now
 	timeNow = time.Now
-	// function variable of make cache map
-	initCacheMap = func() map[string]cacheData {
-		return make(map[string]cacheData)
-	}
 )
 
 type cacheData struct {
@@ -29,7 +25,7 @@ type cache struct {
 // Returns a new Cache instance
 func New() Cache {
 	return &cache{
-		cacheMap: initCacheMap(),
+		cacheMap: make(map[string]cacheData),
 	}
 }
 
@@ -56,11 +52,6 @@ func (c cache) Set(k string, v any) {
 		Data:     v,
 		ExpireAt: expireAt(),
 	}
-}
-
-// Get the cache map
-func (c cache) CacheMap() map[string]cacheData {
-	return c.cacheMap
 }
 
 func expireAt() time.Time {

--- a/pkg/localcache/localcache_test.go
+++ b/pkg/localcache/localcache_test.go
@@ -75,10 +75,10 @@ func TestSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := New()
+			c := New().(*cache)
 			c.Set(tt.args.k, tt.args.v)
 
-			cacheMap := c.CacheMap()
+			cacheMap := c.cacheMap
 
 			if got := cacheMap[tt.args.k].Data; !reflect.DeepEqual(got, tt.args.v) || reflect.TypeOf(got) != reflect.TypeOf(tt.args.v) {
 				t.Errorf("Get() = %v %v, want %v %v", got, reflect.TypeOf(got), tt.args.v, reflect.TypeOf(tt.args.v))
@@ -172,12 +172,8 @@ func TestGet(t *testing.T) {
 		}
 	}
 
-	// mock initCacheMap
-	initCacheMap = func() map[string]cacheData {
-		return mockMap
-	}
-
-	c := New()
+	c := New().(*cache)
+	c.cacheMap = mockMap
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/localcache/localcache_test.go
+++ b/pkg/localcache/localcache_test.go
@@ -1,0 +1,231 @@
+package localcache
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name string
+		want Cache
+	}{
+		{
+			name: "TestNew",
+			want: &cache{
+				cacheMap: make(map[string]cacheData),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSet(t *testing.T) {
+	type args struct {
+		k string
+		v any
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Test Set string",
+			args: args{
+				k: "hello",
+				v: "world",
+			},
+		},
+		{
+			name: "Test Set int",
+			args: args{
+				k: "hello",
+				v: 123,
+			},
+		},
+		{
+			name: "Test Set struct",
+			args: args{
+				k: "hello",
+				v: struct {
+					Name string
+					Age  int
+				}{
+					Name: "John",
+					Age:  18,
+				},
+			},
+		},
+		{
+			name: "Test Set nil",
+			args: args{
+				k: "hello",
+				v: nil,
+			},
+		},
+		{
+			name: "Test Set empty string",
+			args: args{
+				k: "",
+				v: "world",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New()
+			c.Set(tt.args.k, tt.args.v)
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	type args struct {
+		k string
+		v any
+	}
+	tests := []struct {
+		name string
+		args args
+		want any
+	}{
+		{
+			name: "Test Get string",
+			args: args{
+				k: "hello",
+				v: "world",
+			},
+			want: "world",
+		},
+		{
+			name: "Test Get int",
+			args: args{
+				k: "hello",
+				v: 123,
+			},
+			want: 123,
+		},
+		{
+			name: "Test Get struct",
+			args: args{
+				k: "hello",
+				v: struct {
+					Name string
+					Age  int
+				}{
+					Name: "John",
+					Age:  18,
+				},
+			},
+			want: struct {
+				Name string
+				Age  int
+			}{
+				Name: "John",
+				Age:  18,
+			},
+		},
+
+		{
+			name: "Test Get nil",
+			args: args{
+				k: "hello",
+				v: nil,
+			},
+			want: nil,
+		},
+
+		{
+			name: "Test Get empty string",
+			args: args{
+				k: "hello",
+				v: "",
+			},
+			want: "",
+		},
+
+		{
+			name: "Test Get empty struct",
+			args: args{
+				k: "hello",
+				v: struct{}{},
+			},
+			want: struct{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New()
+			c.Set(tt.args.k, tt.args.v)
+			if got := c.Get(tt.args.k); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTTL(t *testing.T) {
+	type args struct {
+		k string
+		v any
+	}
+	tests := []struct {
+		name     string
+		args     args
+		timePass time.Duration
+		want     any
+	}{
+		{
+			name: "Test Get before TTL",
+			args: args{
+				k: "hello",
+				v: "world",
+			},
+			timePass: (TTL - 1) * time.Second,
+			want:     "world",
+		},
+		{
+			name: "Test Get after TTL",
+			args: args{
+				k: "hello",
+				v: "world",
+			},
+			timePass: (TTL + 1) * time.Second,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// mock time start
+			timeNow = func() time.Time { return time.Unix(1629446406, 0) }
+
+			c := New()
+			c.Set(tt.args.k, tt.args.v)
+
+			// mock time passes
+			timeNow = func() time.Time { return time.Unix(1629446406, 0).Add(tt.timePass) }
+
+			if got := c.Get(tt.args.k); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKeyNotExists(t *testing.T) {
+	c := New()
+	if got := c.Get("hello"); got != nil {
+		t.Errorf("Get() = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
Implement a package called `localcache` including two public methods `Get` and `Set` within an interface `Cache`. `Get` gets the value related to a key which is a string type. `Set` sets the key/value pair in the local cache implemented by a map. Please satisfy the following requirement:
* `Set` only keeps a key within 30 seconds.
* `Set` overwrites a value with the same key.
* The value in the cache would be any kind of data in Go.
* Separate the interface and implementation in different files
* Need to implement a public method called `New()` to initialize the instance (as below).
* Need follow up the guideline mentioned in `Code Review Comments`.
* Need unit test for this package. 3rd-party packages including `stretchr/testify` or `testing` is welcome.

[asana](https://app.asana.com/0/0/1204012059022971/f)